### PR TITLE
Allow overriding base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:latest
+ARG BASE_IMAGE=golang:latest
+
+FROM $BASE_IMAGE
 
 RUN go install mvdan.cc/sh/v3/cmd/shfmt@v3
 


### PR DESCRIPTION
I recently experienced the following error in a CI run:

```
429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

The solution was to avoid docker-hub, and use a different container registry to avoid getting rate-limited. For example: `docker build --build-arg BASE_IMAGE=public.ecr.aws/docker/library/golang:latest .`
