### PR TITLE
Add editorconfig to represent current settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false


### PR DESCRIPTION
This will prevent inconsistent line endings and other issues across editors that support `.editorconfig` files